### PR TITLE
Add server refresh after permission changes

### DIFF
--- a/Paper/src/main/java/de/murmelmeister/essentials/MurmelEssentials.java
+++ b/Paper/src/main/java/de/murmelmeister/essentials/MurmelEssentials.java
@@ -3,6 +3,7 @@ package de.murmelmeister.essentials;
 import de.murmelmeister.essentials.api.Ranks;
 import de.murmelmeister.essentials.files.MySQL;
 import de.murmelmeister.essentials.manager.ListenerManager;
+import de.murmelmeister.essentials.utils.PluginMessageRefresh;
 import de.murmelmeister.murmelapi.MurmelAPI;
 import de.murmelmeister.murmelapi.group.Group;
 import de.murmelmeister.murmelapi.permission.Permission;
@@ -11,10 +12,12 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 public final class MurmelEssentials extends JavaPlugin {
     private final MySQL mySQL;
+    private static final PluginMessageRefresh PLUGIN_MESSAGE_REFRESH = new PluginMessageRefresh();
 
     @Override
     public void onDisable() {
         mySQL.disconnect();
+        getServer().getMessenger().unregisterIncomingPluginChannel(this, "permission:refresh", PLUGIN_MESSAGE_REFRESH);
     }
 
     @Override
@@ -22,6 +25,7 @@ public final class MurmelEssentials extends JavaPlugin {
         mySQL.connect();
         ListenerManager.register(this);
         Ranks.updatePlayers(this, getServer());
+        getServer().getMessenger().registerIncomingPluginChannel(this, "permission:refresh", PLUGIN_MESSAGE_REFRESH);
     }
 
     public MurmelEssentials() {

--- a/Paper/src/main/java/de/murmelmeister/essentials/api/Ranks.java
+++ b/Paper/src/main/java/de/murmelmeister/essentials/api/Ranks.java
@@ -5,6 +5,7 @@ import de.murmelmeister.essentials.utils.HexColor;
 import de.murmelmeister.murmelapi.group.Group;
 import de.murmelmeister.murmelapi.group.settings.GroupColorType;
 import de.murmelmeister.murmelapi.user.User;
+import de.murmelmeister.murmelapi.utils.update.RefreshUtil;
 import io.papermc.paper.event.player.AsyncChatEvent;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
@@ -17,6 +18,7 @@ import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.scoreboard.Team;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -27,15 +29,22 @@ public final class Ranks {
     private static final String PERMISSION_CHAT_HEX = "murmelessentials.chat.hex";
 
     public static void updatePlayers(MurmelEssentials instance, Server server) {
+        var hasUpdateOccurred = new AtomicBoolean(false);
+
+        RefreshUtil.setRefreshListener(() -> hasUpdateOccurred.set(true));
+
         server.getScheduler().runTaskTimerAsynchronously(instance, () -> {
-            var group = instance.getGroup();
-            var user = instance.getUser();
-            for (var player : server.getOnlinePlayers()) {
-                setPlayerTeams(group, user, player);
-                setPlayerListName(group, user, player);
-                player.updateCommands(); // Update the player commands
+            if (hasUpdateOccurred.get()) {
+                var group = instance.getGroup();
+                var user = instance.getUser();
+                for (var player : server.getOnlinePlayers()) {
+                    setPlayerTeams(group, user, player);
+                    setPlayerListName(group, user, player);
+                    player.updateCommands(); // Update the player commands
+                }
+                hasUpdateOccurred.set(false);
             }
-        }, 10L, 5 * 20L);
+        }, 10L, 2 * 20L);
     }
 
     @SuppressWarnings("deprecation")

--- a/Paper/src/main/java/de/murmelmeister/essentials/listeners/CustomPermissionListener.java
+++ b/Paper/src/main/java/de/murmelmeister/essentials/listeners/CustomPermissionListener.java
@@ -3,9 +3,12 @@ package de.murmelmeister.essentials.listeners;
 import de.murmelmeister.essentials.MurmelEssentials;
 import de.murmelmeister.essentials.api.CustomPermission;
 import de.murmelmeister.essentials.manager.ListenerManager;
+import de.murmelmeister.murmelapi.utils.update.RefreshUtil;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerLoginEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 
 import java.lang.reflect.Field;
 
@@ -21,5 +24,15 @@ public final class CustomPermissionListener extends ListenerManager{
         field.setAccessible(true);
         field.set(player, new CustomPermission(player, this.permission));
         field.setAccessible(false);
+    }
+
+    @EventHandler
+    public void handlePlayerJoin(PlayerJoinEvent event) {
+        RefreshUtil.markAsRefreshed();
+    }
+
+    @EventHandler
+    public void handlePlayerQuit(PlayerQuitEvent event) {
+        RefreshUtil.markAsRefreshed();
     }
 }

--- a/Paper/src/main/java/de/murmelmeister/essentials/utils/PluginMessageRefresh.java
+++ b/Paper/src/main/java/de/murmelmeister/essentials/utils/PluginMessageRefresh.java
@@ -1,0 +1,16 @@
+package de.murmelmeister.essentials.utils;
+
+import de.murmelmeister.murmelapi.utils.update.RefreshUtil;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.messaging.PluginMessageListener;
+import org.jetbrains.annotations.NotNull;
+
+public final class PluginMessageRefresh implements PluginMessageListener {
+    @Override
+    public void onPluginMessageReceived(@NotNull String channel, @NotNull Player player, byte @NotNull [] message) {
+        if (channel.equals("permission:refresh")) {
+            var msg = new String(message);
+            if (msg.equals("refresh")) RefreshUtil.markAsRefreshed();
+        }
+    }
+}

--- a/Velocity/src/main/java/de/murmelmeister/essentials/MurmelEssentials.java
+++ b/Velocity/src/main/java/de/murmelmeister/essentials/MurmelEssentials.java
@@ -5,7 +5,9 @@ import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.proxy.ProxyInitializeEvent;
 import com.velocitypowered.api.event.proxy.ProxyShutdownEvent;
 import com.velocitypowered.api.plugin.Plugin;
+import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.ProxyServer;
+import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
 import de.murmelmeister.essentials.api.CustomPermission;
 import de.murmelmeister.essentials.api.PlayTimeUpdater;
 import de.murmelmeister.essentials.files.MySQL;
@@ -18,17 +20,21 @@ import de.murmelmeister.murmelapi.playtime.PlayTime;
 import de.murmelmeister.murmelapi.user.User;
 import org.slf4j.Logger;
 
+import java.nio.charset.StandardCharsets;
+
 @Plugin(id = "murmelessentials", name = "MurmelEssentials", version = "0.0.1", description = "MurmelEssentials is a plugin that adds a lot of useful commands to your server.", authors = {"Murmelmeister"}, url = "https://www.youtube.com/Murmelmeister")
 public final class MurmelEssentials {
     private final Logger logger;
     private final ProxyServer proxyServer;
 
     private MySQL mySQL;
+    private static final MinecraftChannelIdentifier CHANNEL = MinecraftChannelIdentifier.create("permission", "refresh");
 
     @Inject
     public MurmelEssentials(Logger logger, ProxyServer proxyServer) {
         this.logger = logger;
         this.proxyServer = proxyServer;
+        proxyServer.getChannelRegistrar().register(CHANNEL);
     }
 
     @Subscribe
@@ -60,5 +66,13 @@ public final class MurmelEssentials {
 
     public Permission getPermission() {
         return MurmelAPI.getPermission();
+    }
+
+    public static void playerSendRefreshMessage(Player player) {
+        player.sendPluginMessage(CHANNEL, "refresh".getBytes());
+    }
+
+    public static void serverSendRefreshMessage(ProxyServer server) {
+        server.getAllServers().parallelStream().forEach(registeredServer -> registeredServer.sendPluginMessage(CHANNEL, "refresh".getBytes(StandardCharsets.UTF_8)));
     }
 }

--- a/Velocity/src/main/java/de/murmelmeister/essentials/commands/PermissionCommand.java
+++ b/Velocity/src/main/java/de/murmelmeister/essentials/commands/PermissionCommand.java
@@ -2,6 +2,8 @@ package de.murmelmeister.essentials.commands;
 
 import com.velocitypowered.api.command.CommandSource;
 import com.velocitypowered.api.proxy.Player;
+import com.velocitypowered.api.proxy.ProxyServer;
+import de.murmelmeister.essentials.MurmelEssentials;
 import de.murmelmeister.essentials.commands.subcomamnd.SubGroupEdit;
 import de.murmelmeister.essentials.commands.subcomamnd.SubParent;
 import de.murmelmeister.essentials.commands.subcomamnd.SubPermission;
@@ -25,6 +27,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class PermissionCommand extends CommandManager {
+    private final ProxyServer server;
     private final Group group;
     private final User user;
 
@@ -38,7 +41,8 @@ public class PermissionCommand extends CommandManager {
     private final SubParent subParent;
     private final SubPermission subPermission;
 
-    public PermissionCommand(Permission permission, Group group, User user) {
+    public PermissionCommand(ProxyServer server, Permission permission, Group group, User user) {
+        this.server = server;
         this.group = group;
         this.user = user;
         this.groupSettings = group.getSettings();
@@ -47,9 +51,9 @@ public class PermissionCommand extends CommandManager {
         this.groupPermission = group.getPermission();
         this.userParent = user.getParent();
         this.userPermission = user.getPermission();
-        this.subGroupEdit = new SubGroupEdit(this, group, user, groupSettings, groupColorSettings);
-        this.subParent = new SubParent(this, group, user, groupParent, userParent);
-        this.subPermission = new SubPermission(this, permission, user, groupParent, groupPermission, userPermission);
+        this.subGroupEdit = new SubGroupEdit(server, this, group, user, groupSettings, groupColorSettings);
+        this.subParent = new SubParent(server, this, group, user, groupParent, userParent);
+        this.subPermission = new SubPermission(server, this, permission, user, groupParent, groupPermission, userPermission);
     }
 
     @Override
@@ -189,6 +193,7 @@ public class PermissionCommand extends CommandManager {
             return;
         }
         group.createNewGroup(groupName, creatorId, Integer.parseInt(args[3]), args[4]);
+        MurmelEssentials.serverSendRefreshMessage(server);
         sendSourceMessage(source, "§3Group §e%s §3is now created.", groupName);
     }
 
@@ -198,6 +203,7 @@ public class PermissionCommand extends CommandManager {
             return;
         }
         group.deleteGroup(groupId);
+        MurmelEssentials.serverSendRefreshMessage(server);
         sendSourceMessage(source, "§3Group §e%s §3is now deleted.", groupName);
     }
 
@@ -211,6 +217,7 @@ public class PermissionCommand extends CommandManager {
         var teamId = groupSettings.getTeamId(groupId);
         group.rename(groupId, newName);
         groupSettings.setTeamId(groupId, teamId.replace(oldName, newName));
+        MurmelEssentials.serverSendRefreshMessage(server);
         sendSourceMessage(source, "§3Group is now renamed to §e%s", args[3]);
     }
 }

--- a/Velocity/src/main/java/de/murmelmeister/essentials/commands/subcomamnd/SubGroupEdit.java
+++ b/Velocity/src/main/java/de/murmelmeister/essentials/commands/subcomamnd/SubGroupEdit.java
@@ -1,6 +1,8 @@
 package de.murmelmeister.essentials.commands.subcomamnd;
 
 import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.proxy.ProxyServer;
+import de.murmelmeister.essentials.MurmelEssentials;
 import de.murmelmeister.essentials.manager.CommandManager;
 import de.murmelmeister.essentials.utils.PermissionSyntaxUtil;
 import de.murmelmeister.murmelapi.group.Group;
@@ -12,13 +14,15 @@ import de.murmelmeister.murmelapi.user.User;
 import static de.murmelmeister.essentials.manager.CommandManager.sendSourceMessage;
 
 public final class SubGroupEdit {
+    private final ProxyServer server;
     private final CommandManager commandManager;
     private final Group group;
     private final User user;
     private final GroupSettings groupSettings;
     private final GroupColorSettings groupColorSettings;
 
-    public SubGroupEdit(CommandManager commandManager, Group group, User user, GroupSettings groupSettings, GroupColorSettings groupColorSettings) {
+    public SubGroupEdit(ProxyServer server, CommandManager commandManager, Group group, User user, GroupSettings groupSettings, GroupColorSettings groupColorSettings) {
+        this.server = server;
         this.commandManager = commandManager;
         this.group = group;
         this.user = user;
@@ -62,6 +66,7 @@ public final class SubGroupEdit {
                     break;
                 }
                 groupColorSettings.setPrefix(type, groupId, creator, message);
+                MurmelEssentials.serverSendRefreshMessage(server);
                 sendSourceMessage(source, "§3Prefix is now §e%s", message);
             }
             case "suffix" -> {
@@ -72,6 +77,7 @@ public final class SubGroupEdit {
                     break;
                 }
                 groupColorSettings.setSuffix(type, groupId, creator, message);
+                MurmelEssentials.serverSendRefreshMessage(server);
                 sendSourceMessage(source, "§3Suffix is now §e%s", message);
             }
             case "color" -> {
@@ -82,6 +88,7 @@ public final class SubGroupEdit {
                     break;
                 }
                 groupColorSettings.setColor(type, groupId, creator, message);
+                MurmelEssentials.serverSendRefreshMessage(server);
                 sendSourceMessage(source, "§3Color is now §e%s", message);
             }
             default -> PermissionSyntaxUtil.syntaxGroupEdit(source);
@@ -95,6 +102,7 @@ public final class SubGroupEdit {
         }
         try {
             groupSettings.setSortId(groupId, Integer.parseInt(args[4]));
+            MurmelEssentials.serverSendRefreshMessage(server);
             sendSourceMessage(source, "§3Sort id is now set to §e%s", args[4]);
         } catch (NumberFormatException e) {
             sendSourceMessage(source, "§cInvalid sort id");
@@ -110,6 +118,7 @@ public final class SubGroupEdit {
             var id = Integer.parseInt(args[4]);
             var teamId = id + group.getName(groupId);
             groupSettings.setTeamId(groupId, teamId);
+            MurmelEssentials.serverSendRefreshMessage(server);
             sendSourceMessage(source, "§3Team id is now set to §e%s", teamId);
         } catch (NumberFormatException e) {
             sendSourceMessage(source, "§cInvalid team id");

--- a/Velocity/src/main/java/de/murmelmeister/essentials/commands/subcomamnd/SubParent.java
+++ b/Velocity/src/main/java/de/murmelmeister/essentials/commands/subcomamnd/SubParent.java
@@ -1,6 +1,8 @@
 package de.murmelmeister.essentials.commands.subcomamnd;
 
 import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.proxy.ProxyServer;
+import de.murmelmeister.essentials.MurmelEssentials;
 import de.murmelmeister.essentials.manager.CommandManager;
 import de.murmelmeister.essentials.utils.PermissionSyntaxUtil;
 import de.murmelmeister.murmelapi.group.Group;
@@ -12,13 +14,15 @@ import de.murmelmeister.murmelapi.utils.TimeUtil;
 import static de.murmelmeister.essentials.manager.CommandManager.sendSourceMessage;
 
 public final class SubParent {
+    private final ProxyServer server;
     private final CommandManager commandManager;
     private final Group group;
     private final User user;
     private final GroupParent groupParent;
     private final UserParent userParent;
 
-    public SubParent(CommandManager commandManager, Group group, User user, GroupParent groupParent, UserParent userParent) {
+    public SubParent(ProxyServer server, CommandManager commandManager, Group group, User user, GroupParent groupParent, UserParent userParent) {
+        this.server = server;
         this.commandManager = commandManager;
         this.group = group;
         this.user = user;
@@ -57,6 +61,7 @@ public final class SubParent {
         if (args.length == 5) {
             if (isUser) userParent.addParent(id, creatorId, parentId, -1);
             else groupParent.addParent(id, creatorId, parentId, -1);
+            MurmelEssentials.serverSendRefreshMessage(server);
             sendSourceMessage(source, "§3Parent §e%s §3is now added.", parentName);
             return;
         }
@@ -71,6 +76,7 @@ public final class SubParent {
         }
         if (isUser) userParent.addParent(id, creatorId, parentId, time);
         else groupParent.addParent(id, creatorId, parentId, time);
+        MurmelEssentials.serverSendRefreshMessage(server);
         sendSourceMessage(source, "§3Parent §e%s §3is now added for §e%s", parentName, getParentExpiredDate(isUser, id, parentId));
     }
 
@@ -91,6 +97,7 @@ public final class SubParent {
             }
             userParent.removeParent(id, parentId);
         } else groupParent.removeParent(id, parentId);
+        MurmelEssentials.serverSendRefreshMessage(server);
         sendSourceMessage(source, "§3Parent §e%s §3is now removed.", parentName);
     }
 
@@ -99,6 +106,7 @@ public final class SubParent {
             userParent.clearParent(id);
             userParent.addParent(id, -1, group.getDefaultGroup(), -1);
         } else groupParent.clearParent(id);
+        MurmelEssentials.serverSendRefreshMessage(server);
         sendSourceMessage(source, "§3All parents are now cleared.");
     }
 
@@ -151,14 +159,17 @@ public final class SubParent {
         switch (args[6]) {
             case "set" -> {
                 var expiredDate = isUser ? userParent.setExpiredTime(id, parentId, time) : groupParent.setExpiredTime(id, parentId, time);
+                MurmelEssentials.serverSendRefreshMessage(server);
                 sendSourceMessage(source, "§3Expired time for §e%s §3is now §e%s", parentName, expiredDate);
             }
             case "add" -> {
                 var expiredDate = isUser ? userParent.addExpiredTime(id, parentId, time) : groupParent.addExpiredTime(id, parentId, time);
+                MurmelEssentials.serverSendRefreshMessage(server);
                 sendSourceMessage(source, "§3Expired time for §e%s §3is now §e%s", parentName, expiredDate);
             }
             case "remove" -> {
                 var expiredDate = isUser ? userParent.removeExpiredTime(id, parentId, time) : groupParent.removeExpiredTime(id, parentId, time);
+                MurmelEssentials.serverSendRefreshMessage(server);
                 sendSourceMessage(source, "§3Expired time for §e%s §3is now §e%s", parentName, expiredDate);
             }
             default -> PermissionSyntaxUtil.syntaxParent(source, isUser);

--- a/Velocity/src/main/java/de/murmelmeister/essentials/commands/subcomamnd/SubPermission.java
+++ b/Velocity/src/main/java/de/murmelmeister/essentials/commands/subcomamnd/SubPermission.java
@@ -1,6 +1,8 @@
 package de.murmelmeister.essentials.commands.subcomamnd;
 
 import com.velocitypowered.api.command.CommandSource;
+import com.velocitypowered.api.proxy.ProxyServer;
+import de.murmelmeister.essentials.MurmelEssentials;
 import de.murmelmeister.essentials.manager.CommandManager;
 import de.murmelmeister.essentials.utils.PermissionSyntaxUtil;
 import de.murmelmeister.murmelapi.group.parent.GroupParent;
@@ -13,6 +15,7 @@ import de.murmelmeister.murmelapi.utils.TimeUtil;
 import static de.murmelmeister.essentials.manager.CommandManager.sendSourceMessage;
 
 public final class SubPermission {
+    private final ProxyServer server;
     private final CommandManager commandManager;
     private final Permission permission;
     private final User user;
@@ -20,7 +23,8 @@ public final class SubPermission {
     private final GroupPermission groupPermission;
     private final UserPermission userPermission;
 
-    public SubPermission(CommandManager commandManager, Permission permission, User user, GroupParent groupParent, GroupPermission groupPermission, UserPermission userPermission) {
+    public SubPermission(ProxyServer server, CommandManager commandManager, Permission permission, User user, GroupParent groupParent, GroupPermission groupPermission, UserPermission userPermission) {
+        this.server = server;
         this.commandManager = commandManager;
         this.permission = permission;
         this.user = user;
@@ -66,6 +70,7 @@ public final class SubPermission {
         if (args.length == 5) {
             if (isUser) userPermission.addPermission(id, creatorId, permission, -1);
             else groupPermission.addPermission(id, creatorId, permission, -1);
+            MurmelEssentials.serverSendRefreshMessage(server);
             sendSourceMessage(source, "§3Permission §e%s §3is now added.", permission);
             return;
         }
@@ -80,6 +85,7 @@ public final class SubPermission {
         }
         if (isUser) userPermission.addPermission(id, creatorId, permission, time);
         else groupPermission.addPermission(id, creatorId, permission, time);
+        MurmelEssentials.serverSendRefreshMessage(server);
         sendSourceMessage(source, "§3Permission §e%s §3is now added for §e%s", permission, getPermissionExpiredDate(isUser, id, permission));
     }
 
@@ -93,12 +99,14 @@ public final class SubPermission {
 
         if (isUser) userPermission.removePermission(id, permission);
         else groupPermission.removePermission(id, permission);
+        MurmelEssentials.serverSendRefreshMessage(server);
         sendSourceMessage(source, "§3Permission §e%s §3is now removed.", permission);
     }
 
     private void clearPermission(CommandSource source, boolean isUser, int id) {
         if (isUser) userPermission.clearPermission(id);
         else groupPermission.clearPermission(id);
+        MurmelEssentials.serverSendRefreshMessage(server);
         sendSourceMessage(source, "§3All permissions are now cleared.");
     }
 
@@ -141,14 +149,17 @@ public final class SubPermission {
         switch (args[6]) {
             case "set" -> {
                 var expiredDate = isUser ? userPermission.setExpiredTime(id, permission, time) : groupPermission.setExpiredTime(id, permission, time);
+                MurmelEssentials.serverSendRefreshMessage(server);
                 sendSourceMessage(source, "§3Expired time for §e%s §3is now §e%s", permission, expiredDate);
             }
             case "add" -> {
                 var expiredDate = isUser ? userPermission.addExpiredTime(id, permission, time) : groupPermission.addExpiredTime(id, permission, time);
+                MurmelEssentials.serverSendRefreshMessage(server);
                 sendSourceMessage(source, "§3Expired time for §e%s §3is now §e%s", permission, expiredDate);
             }
             case "remove" -> {
                 var expiredDate = isUser ? userPermission.removeExpiredTime(id, permission, time) : groupPermission.removeExpiredTime(id, permission, time);
+                MurmelEssentials.serverSendRefreshMessage(server);
                 sendSourceMessage(source, "§3Expired time for §e%s §3is now §e%s", permission, expiredDate);
             }
             default -> PermissionSyntaxUtil.syntaxPermission(source, isUser);

--- a/Velocity/src/main/java/de/murmelmeister/essentials/listeners/PermissionListener.java
+++ b/Velocity/src/main/java/de/murmelmeister/essentials/listeners/PermissionListener.java
@@ -5,6 +5,7 @@ import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.permission.PermissionsSetupEvent;
 import com.velocitypowered.api.event.player.ServerConnectedEvent;
 import com.velocitypowered.api.proxy.Player;
+import de.murmelmeister.essentials.MurmelEssentials;
 import de.murmelmeister.essentials.api.CustomPermission;
 import de.murmelmeister.murmelapi.group.Group;
 import de.murmelmeister.murmelapi.permission.Permission;
@@ -42,5 +43,6 @@ public final class PermissionListener {
         user.joinUser(player.getUniqueId(), player.getUsername());
         var uid = user.getId(player.getUniqueId());
         user.getParent().addParent(uid, -1, group.getDefaultGroup(), -1);
+        MurmelEssentials.playerSendRefreshMessage(player);
     }
 }

--- a/Velocity/src/main/java/de/murmelmeister/essentials/manager/CommandManager.java
+++ b/Velocity/src/main/java/de/murmelmeister/essentials/manager/CommandManager.java
@@ -17,7 +17,7 @@ public abstract class CommandManager implements SimpleCommand {
         var user = instance.getUser();
         var permission = instance.getPermission();
         var playTime = instance.getPlayTime();
-        addCommand(server, "permission", new PermissionCommand(permission, group, user));
+        addCommand(server, "permission", new PermissionCommand(server, permission, group, user));
         //addCommand(server, "playtime", new PlayTimeCommand(user, playTime));
         server.getCommandManager().register(PlayTimeCommand.createBrigadierCommand(user, playTime));
     }


### PR DESCRIPTION
Modified various classes to trigger a server refresh when changes are made to group or user permissions. This new functionality uses MinecraftChannelIdentifier to send messages after changes in Group, Parent, and Permission commands are updated, ensuring all servers are synced with the latest permissions configuration.